### PR TITLE
Bring the documentation to the style guide.

### DIFF
--- a/documentation/docs/api_reference.md
+++ b/documentation/docs/api_reference.md
@@ -13,6 +13,6 @@ keywords:
 
 # API Reference
 
-You can find specifications of the API exposed by INX-Indexer in the links below:
+You can find the specifications of the INX-Indexer API by following the link below:
 
 - [UTXO Indexer API](https://github.com/iotaledger/tips/blob/main/tips/TIP-0026/tip-0026.md)

--- a/documentation/docs/how_to/query_outputs.md
+++ b/documentation/docs/how_to/query_outputs.md
@@ -12,30 +12,46 @@ keywords:
 - how to
 ---
 
+# Querying Basic Outputs
 
-# Query the Indexer for Outputs
+While the protocol offers different [kinds of outputs](https://github.com/lzpap/tips/blob/master/tips/TIP-0018/tip-0018.md#output-design) and [ways to manage](https://wiki.iota.org/introduction/develop/explanations/what_is_stardust/unlock_conditions) them, most of the time token owners would simply want to know how many tokens they have at their unrestricted disposal. For that you would have to query outputs that satisfy the following limitations:
 
-Outputs support a wide range of unlock conditions. Some of them are time-based or require to issue a transaction to claim final ownership of the outputs. Some usecases might want to skip these kind of outputs to avoid the required complexity of comparing time or issuing claiming transactions. The indexer allows you to filter out these outputs by using simple query filters.
+1. The output must be [basic](https://github.com/lzpap/tips/blob/master/tips/TIP-0018/tip-0018.md#basic-output).
+2. The output must have an address unlock condition that matches your address (in this example it will be `rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j`).
+3. The output must not have any other conditions.
+
+## Construct the Query
+
+To query data from the Shimmer test network, you can use the public node that is run by IOTA Foundation. Its [indexer extension API](https://editor.swagger.io/?url=https://raw.githubusercontent.com/iotaledger/tips/indexer-api/tips/TIP-0026/indexer-rest-api.yaml) is exposed at the following URL:
+
+`https://api.testnet.shimmer.network/api/indexer/v1/outputs/basic`
+
+It returns a thousand basic outputs as there are no any query parameters yet. These parameters would be:
 
 
-## "Simple Outputs"
+|The Parameter                                                              |Its Meaning                                                  |
+|---                                                                        |---                                                          |
+|`address=rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j`  | Has an address unlock condition with the specified address. |
+|`hasStorageDepositReturn=false`                                            | Does not have a storage deposit return unlock condition.    |
+|`hasExpiration=false`                                                      | Does not have an expiration unlock condition.               |
+|`hasTimelock=false`                                                        | And does not a timelock unlock condition.                   |
+|---                                                                        |---                                                          |
 
-We can define "Simple Outputs" to be the ones that can be unlocked by a single address, have no timelock or expiration and have no storage deposit return conditions. These ouputs are 100% owned by the given address and can be spent without any constraints.
+Combining everything into the query:
 
-### Example
+```
+https://api.testnet.shimmer.network/api/indexer/v1/outputs/basic?address=rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j&hasStorageDepositReturn=false&hasExpiration=false&hasTimelock=false
+```
 
-An example indexer query for such simple outputs could be:
+The result will be a JSON with the list of output IDs in the `items` array:
 
-`https://api.testnet.shimmer.network/api/indexer/v1/outputs/basic?address=rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j&hasStorageDepositReturn=false&hasExpiration=false&hasTimelock=false`
-
-Let's break it down into the components:
-
-* `/api/indexer/v1/outputs/basic`: we are asking the indexer for outputs of type `BasicOutput`. These are normal outputs that carry value in form of the base token and optionally a set of native tokens. You can check [TIP-18](https://github.com/lzpap/tips/blob/master/tips/TIP-0018/tip-0018.md) for more information about the outputs that are supported by the network.
-
-* `address=rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j` : we are asking the indexer to only return the outputs, where the `Address Unlock Condition` matches the given address `rms1qrnspqhq6jhkujxak8aw9vult5uaa38hj8fv9klsvnvchdsf2q06wmr2c7j`
-
-* `hasStorageDepositReturn=false`: by adding the `hasStorageDepositReturn` query parameter we are explicitely asking the indexer to look at the `Storage Deposit Return Unlock Condition` of the outputs. By passing `false` we tell the indexer to only return outputs that have no such condition.
-
-* `hasExpiration=false`: by adding the `hasExpiration` query parameter, we can tell the indexer to look for `Expiration Unlock Condition` and by passing `false` we can ask it to only return outputs that have no expiration condition.
-
-* `hasTimelock=false`: by adding the `hasTimelock` query parameter, we are asking the indexer to look for `Timelock Unlock Condition` and by passing `false` we tell it to only return outputs that have no timelock condition.
+```json
+{
+  "ledgerIndex": 101,
+  "items": [
+    "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790000",
+    "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790100",
+    "0x0c78e998f5177834ecb3bae1596d5056af76e487386eecb19727465b4be86a790200"
+  ]
+}
+```

--- a/documentation/docs/welcome.md
+++ b/documentation/docs/welcome.md
@@ -15,17 +15,19 @@ keywords:
 
 # Welcome to INX-Indexer
 
-INX-Indexer is a ledger indexing tool to provide structured and queryable data to wallets and other applications. 
-The indexer maintains its own database separate from that of the node.
+
+To maintain the ledger state, the Hornet nodes need to quickly read and write information about [transaction outputs](https://wiki.iota.org/learn/about-iota/messages#utxo). The token owners, however, are very concerned about the total balance of all UTXO belonging to their accounts — but this information has no use in maintaining the state. If clients were accessing this information directly, that would cause nodes to waste resources on either restructuring the database or resolving unoptimized queries.
+
+INX-Indexer maintains a separate database and optimizes it for wallet-related queries. This way the Hornet software focuses on maintaining the network and INX-Indexer on presenting its state to clients. You can find more information in the [Ledger Indexing](https://github.com/iotaledger/tips/discussions/53) discussion.
 
 ## Setup
 
-The recommended setup is to use the provided [Docker images](https://hub.docker.com/r/iotaledger/inx-indexer).
-These images are also used in our [HORNET recommended setup using Docker](http://wiki.iota.org/hornet/develop/how_tos/using_docker).
+We recommend you to use the [Docker images](https://hub.docker.com/r/iotaledger/inx-indexer).
+These images are also used in the [Docker setup](http://wiki.iota.org/hornet/develop/how_tos/using_docker) of Hornet.
 
 ## Configuration
 
-The indexer is configured by default to connect to your HORNET instance.
+The indexer connects to the local Hornet instance by default.
 
 You can find all the configuration options in the [configuration section](configuration.md).
 

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -17,7 +17,7 @@ module.exports = {
         },
         {
             type: 'category',
-            label: 'How to',
+            label: 'How To',
             items: [
                 {
                     type: 'doc',
@@ -28,7 +28,7 @@ module.exports = {
         },
         {
             type: 'category',
-            label: 'References',
+            label: 'Reference',
             items: [
                 {
                     type: 'doc',


### PR DESCRIPTION
@lucas-tortora I'm not quite sure how should we capitalize unlock conditions. I went with normal capitalization for technical terms, but it might as well be the Address unlock condition or the *Address* unlock condition, or Address Unlock Condition, depending on which part you consider as a name and which as a technical term.

Also I tried to explain a practical motivation for querying basic outputs without extra conditions. Let me know if I got that wrong.

Also I removed any mention of "simple outputs" because this term seems to be coined for just this guide and will probably do more harm than good. Let me know if I'm wrong and this term will be used widely in the future.