### PR TITLE
Add parameter for AdvertiseAddress

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -27,8 +27,11 @@
     "db": {
       "path": "database"
     },
+    "maxPageSize": 1000
+  },
+  "restAPI": {
     "bindAddress": "localhost:9091",
-    "maxPageSize": 1000,
+    "advertiseAddress": "",
     "debugRequestLoggerEnabled": false
   },
   "profiling": {

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -26,12 +26,12 @@
   "indexer": {
     "db": {
       "path": "database"
-    },
-    "maxPageSize": 1000
+    }
   },
   "restAPI": {
     "bindAddress": "localhost:9091",
     "advertiseAddress": "",
+    "maxPageSize": 1000,
     "debugRequestLoggerEnabled": false
   },
   "profiling": {

--- a/core/indexer/component.go
+++ b/core/indexer/component.go
@@ -132,7 +132,7 @@ func run() error {
 
 		CoreComponent.LogInfo("Starting API server ...")
 
-		_ = server.NewIndexerServer(deps.Indexer, deps.Echo.Group(""), deps.NodeBridge.ProtocolParameters().Bech32HRP, ParamsIndexer.MaxPageSize)
+		_ = server.NewIndexerServer(deps.Indexer, deps.Echo.Group(""), deps.NodeBridge.ProtocolParameters().Bech32HRP, ParamsRestAPI.MaxPageSize)
 
 		go func() {
 			CoreComponent.LogInfof("You can now access the API using: http://%s", ParamsRestAPI.BindAddress)

--- a/core/indexer/params.go
+++ b/core/indexer/params.go
@@ -9,9 +9,6 @@ type ParametersIndexer struct {
 		// Path defines the path to the database folder
 		Path string `default:"database" usage:"the path to the database folder"`
 	} `name:"db"`
-
-	// MaxPageSize defines the maximum number of results that may be returned for each page
-	MaxPageSize int `default:"1000" usage:"the maximum number of results that may be returned for each page"`
 }
 
 // ParametersRestAPI contains the definition of the parameters used by the Indexer HTTP server.
@@ -21,6 +18,9 @@ type ParametersRestAPI struct {
 
 	// AdvertiseAddress defines the address of the Indexer HTTP server which is advertised to the INX Server (optional).
 	AdvertiseAddress string `default:"" usage:"the address of the Indexer HTTP server which is advertised to the INX Server (optional)"`
+
+	// MaxPageSize defines the maximum number of results that may be returned for each page
+	MaxPageSize int `default:"1000" usage:"the maximum number of results that may be returned for each page"`
 
 	// DebugRequestLoggerEnabled defines whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`

--- a/core/indexer/params.go
+++ b/core/indexer/params.go
@@ -10,21 +10,29 @@ type ParametersIndexer struct {
 		Path string `default:"database" usage:"the path to the database folder"`
 	} `name:"db"`
 
+	// MaxPageSize defines the maximum number of results that may be returned for each page
+	MaxPageSize int `default:"1000" usage:"the maximum number of results that may be returned for each page"`
+}
+
+// ParametersRestAPI contains the definition of the parameters used by the Indexer HTTP server.
+type ParametersRestAPI struct {
 	// BindAddress defines the bind address on which the Indexer HTTP server listens.
 	BindAddress string `default:"localhost:9091" usage:"the bind address on which the Indexer HTTP server listens"`
 
-	// MaxPageSize defines the maximum number of results that may be returned for each page
-	MaxPageSize int `default:"1000" usage:"the maximum number of results that may be returned for each page"`
+	// AdvertiseAddress defines the address of the Indexer HTTP server which is advertised to the INX Server (optional).
+	AdvertiseAddress string `default:"" usage:"the address of the Indexer HTTP server which is advertised to the INX Server (optional)"`
 
 	// DebugRequestLoggerEnabled defines whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`
 }
 
 var ParamsIndexer = &ParametersIndexer{}
+var ParamsRestAPI = &ParametersRestAPI{}
 
 var params = &app.ComponentParams{
 	Params: map[string]any{
 		"indexer": ParamsIndexer,
+		"restAPI": ParamsRestAPI,
 	},
 	Masked: nil,
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -120,12 +120,10 @@ Example:
 
 ## <a id="indexer"></a> 4. Indexer
 
-| Name                      | Description                                                      | Type    | Default value    |
-| ------------------------- | ---------------------------------------------------------------- | ------- | ---------------- |
-| [db](#indexer_db)         | Configuration for Database                                       | object  |                  |
-| bindAddress               | The bind address on which the Indexer HTTP server listens        | string  | "localhost:9091" |
-| maxPageSize               | The maximum number of results that may be returned for each page | int     | 1000             |
-| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled         | boolean | false            |
+| Name              | Description                                                      | Type   | Default value |
+| ----------------- | ---------------------------------------------------------------- | ------ | ------------- |
+| [db](#indexer_db) | Configuration for Database                                       | object |               |
+| maxPageSize       | The maximum number of results that may be returned for each page | int    | 1000          |
 
 ### <a id="indexer_db"></a> Database
 
@@ -141,8 +139,26 @@ Example:
       "db": {
         "path": "database"
       },
+      "maxPageSize": 1000
+    }
+  }
+```
+
+## <a id="restapi"></a> 4. RestAPI
+
+| Name                      | Description                                                                             | Type    | Default value    |
+| ------------------------- | --------------------------------------------------------------------------------------- | ------- | ---------------- |
+| bindAddress               | The bind address on which the Indexer HTTP server listens                               | string  | "localhost:9091" |
+| advertiseAddress          | The address of the Indexer HTTP server which is advertised to the INX Server (optional) | string  | ""               |
+| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                                | boolean | false            |
+
+Example:
+
+```json
+  {
+    "restAPI": {
       "bindAddress": "localhost:9091",
-      "maxPageSize": 1000,
+      "advertiseAddress": "",
       "debugRequestLoggerEnabled": false
     }
   }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -120,10 +120,9 @@ Example:
 
 ## <a id="indexer"></a> 4. Indexer
 
-| Name              | Description                                                      | Type   | Default value |
-| ----------------- | ---------------------------------------------------------------- | ------ | ------------- |
-| [db](#indexer_db) | Configuration for Database                                       | object |               |
-| maxPageSize       | The maximum number of results that may be returned for each page | int    | 1000          |
+| Name              | Description                | Type   | Default value |
+| ----------------- | -------------------------- | ------ | ------------- |
+| [db](#indexer_db) | Configuration for Database | object |               |
 
 ### <a id="indexer_db"></a> Database
 
@@ -138,18 +137,18 @@ Example:
     "indexer": {
       "db": {
         "path": "database"
-      },
-      "maxPageSize": 1000
+      }
     }
   }
 ```
 
-## <a id="restapi"></a> 4. RestAPI
+## <a id="restapi"></a> 5. RestAPI
 
 | Name                      | Description                                                                             | Type    | Default value    |
 | ------------------------- | --------------------------------------------------------------------------------------- | ------- | ---------------- |
 | bindAddress               | The bind address on which the Indexer HTTP server listens                               | string  | "localhost:9091" |
 | advertiseAddress          | The address of the Indexer HTTP server which is advertised to the INX Server (optional) | string  | ""               |
+| maxPageSize               | The maximum number of results that may be returned for each page                        | int     | 1000             |
 | debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                                | boolean | false            |
 
 Example:
@@ -159,12 +158,13 @@ Example:
     "restAPI": {
       "bindAddress": "localhost:9091",
       "advertiseAddress": "",
+      "maxPageSize": 1000,
       "debugRequestLoggerEnabled": false
     }
   }
 ```
 
-## <a id="profiling"></a> 5. Profiling
+## <a id="profiling"></a> 6. Profiling
 
 | Name        | Description                                       | Type    | Default value    |
 | ----------- | ------------------------------------------------- | ------- | ---------------- |
@@ -182,7 +182,7 @@ Example:
   }
 ```
 
-## <a id="prometheus"></a> 6. Prometheus
+## <a id="prometheus"></a> 7. Prometheus
 
 | Name            | Description                                                     | Type    | Default value    |
 | --------------- | --------------------------------------------------------------- | ------- | ---------------- |


### PR DESCRIPTION
This PR introduces the `AdvertiseAddress` config parameter, which simplifies the setup in some private network environments.