### PR TITLE
Use a separate cancellable context for the importer

### DIFF
--- a/core/indexer/component.go
+++ b/core/indexer/component.go
@@ -301,10 +301,13 @@ func fillIndexer(ctx context.Context, indexer *indexer.Indexer, protoParams *iot
 		return 0, err
 	}
 
+	importerCtx, importCancel := context.WithCancel(ctx)
+	defer importCancel()
+
+	importer := indexer.ImportTransaction(importerCtx)
+
 	receiveCtx, receiveCancel := context.WithCancel(ctx)
 	defer receiveCancel()
-
-	importer := indexer.ImportTransaction(receiveCtx)
 
 	stream, err := deps.NodeBridge.Client().ReadUnspentOutputs(receiveCtx, &inx.NoParams{})
 	if err != nil {


### PR DESCRIPTION
The receive context is cancelled as soon as we are done with receiving, but there might still be pending insertions. Now the importer is cancelled if there is an error while receiving and we exit the fillIndexer function before it is done.