### PR TITLE
Improved Filtering options

### DIFF
--- a/components/app/app.go
+++ b/components/app/app.go
@@ -14,7 +14,7 @@ var (
 	Name = "inx-indexer"
 
 	// Version of the app.
-	Version = "1.0.0-rc.3"
+	Version = "1.0.0-rc.4"
 )
 
 func App() *app.App {

--- a/pkg/indexer/alias.go
+++ b/pkg/indexer/alias.go
@@ -11,14 +11,14 @@ import (
 )
 
 type alias struct {
-	AliasID          aliasIDBytes  `gorm:"primaryKey;notnull"`
-	OutputID         outputIDBytes `gorm:"unique;notnull"`
-	NativeTokenCount uint32        `gorm:"notnull;type:integer"`
-	StateController  addressBytes  `gorm:"notnull;index:alias_state_controller"`
-	Governor         addressBytes  `gorm:"notnull;index:alias_governor"`
-	Issuer           addressBytes  `gorm:"index:alias_issuer"`
-	Sender           addressBytes  `gorm:"index:alias_sender"`
-	CreatedAt        time.Time     `gorm:"notnull;index:alias_created_at"`
+	AliasID          []byte    `gorm:"primaryKey;notnull"`
+	OutputID         []byte    `gorm:"unique;notnull"`
+	NativeTokenCount uint32    `gorm:"notnull;type:integer"`
+	StateController  []byte    `gorm:"notnull;index:alias_state_controller"`
+	Governor         []byte    `gorm:"notnull;index:alias_governor"`
+	Issuer           []byte    `gorm:"index:alias_issuer"`
+	Sender           []byte    `gorm:"index:alias_sender"`
+	CreatedAt        time.Time `gorm:"notnull;index:alias_created_at"`
 }
 
 func (o *alias) String() string {

--- a/pkg/indexer/alias.go
+++ b/pkg/indexer/alias.go
@@ -156,7 +156,7 @@ func (i *Indexer) aliasQueryWithFilter(opts *AliasFilterOptions) (*gorm.DB, erro
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("(state_controller = ? OR governor = ?)", addr[:], addr[:])
+		query = query.Where("(state_controller = ? OR governor = ?)", addr, addr)
 	}
 
 	if opts.stateController != nil {
@@ -164,7 +164,7 @@ func (i *Indexer) aliasQueryWithFilter(opts *AliasFilterOptions) (*gorm.DB, erro
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("state_controller = ?", addr[:])
+		query = query.Where("state_controller = ?", addr)
 	}
 
 	if opts.governor != nil {
@@ -172,7 +172,7 @@ func (i *Indexer) aliasQueryWithFilter(opts *AliasFilterOptions) (*gorm.DB, erro
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("governor = ?", addr[:])
+		query = query.Where("governor = ?", addr)
 	}
 
 	if opts.sender != nil {
@@ -180,7 +180,7 @@ func (i *Indexer) aliasQueryWithFilter(opts *AliasFilterOptions) (*gorm.DB, erro
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("sender = ?", addr[:])
+		query = query.Where("sender = ?", addr)
 	}
 
 	if opts.issuer != nil {
@@ -188,7 +188,7 @@ func (i *Indexer) aliasQueryWithFilter(opts *AliasFilterOptions) (*gorm.DB, erro
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("issuer = ?", addr[:])
+		query = query.Where("issuer = ?", addr)
 	}
 
 	if opts.createdBefore != nil {

--- a/pkg/indexer/basic_output.go
+++ b/pkg/indexer/basic_output.go
@@ -11,17 +11,17 @@ import (
 )
 
 type basicOutput struct {
-	OutputID                    outputIDBytes `gorm:"primaryKey;notnull"`
-	NativeTokenCount            uint32        `gorm:"notnull;type:integer"`
-	Sender                      addressBytes  `gorm:"index:basic_outputs_sender_tag"`
-	Tag                         []byte        `gorm:"index:basic_outputs_sender_tag"`
-	Address                     addressBytes  `gorm:"notnull;index:basic_outputs_address"`
+	OutputID                    []byte `gorm:"primaryKey;notnull"`
+	NativeTokenCount            uint32 `gorm:"notnull;type:integer"`
+	Sender                      []byte `gorm:"index:basic_outputs_sender_tag"`
+	Tag                         []byte `gorm:"index:basic_outputs_sender_tag"`
+	Address                     []byte `gorm:"notnull;index:basic_outputs_address"`
 	StorageDepositReturn        *uint64
-	StorageDepositReturnAddress addressBytes `gorm:"index:basic_outputs_storage_deposit_return_address"`
+	StorageDepositReturnAddress []byte `gorm:"index:basic_outputs_storage_deposit_return_address"`
 	TimelockTime                *time.Time
 	ExpirationTime              *time.Time
-	ExpirationReturnAddress     addressBytes `gorm:"index:basic_outputs_expiration_return_address"`
-	CreatedAt                   time.Time    `gorm:"notnull;index:basic_outputs_created_at"`
+	ExpirationReturnAddress     []byte    `gorm:"index:basic_outputs_expiration_return_address"`
+	CreatedAt                   time.Time `gorm:"notnull;index:basic_outputs_created_at"`
 }
 
 func (o *basicOutput) String() string {

--- a/pkg/indexer/basic_output.go
+++ b/pkg/indexer/basic_output.go
@@ -207,7 +207,7 @@ func (i *Indexer) basicOutputsQueryWithFilter(opts *BasicOutputFilterOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("(address = ? OR expiration_return_address = ? OR storage_deposit_return_address = ?)", addr[:], addr[:], addr[:])
+		query = query.Where("(address = ? OR expiration_return_address = ? OR storage_deposit_return_address = ?)", addr, addr, addr)
 	}
 
 	if opts.address != nil {
@@ -215,7 +215,7 @@ func (i *Indexer) basicOutputsQueryWithFilter(opts *BasicOutputFilterOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("address = ?", addr[:])
+		query = query.Where("address = ?", addr)
 	}
 
 	if opts.hasStorageDepositReturnCondition != nil {
@@ -231,7 +231,7 @@ func (i *Indexer) basicOutputsQueryWithFilter(opts *BasicOutputFilterOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("storage_deposit_return_address = ?", addr[:])
+		query = query.Where("storage_deposit_return_address = ?", addr)
 	}
 
 	if opts.hasExpirationCondition != nil {
@@ -247,7 +247,7 @@ func (i *Indexer) basicOutputsQueryWithFilter(opts *BasicOutputFilterOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("expiration_return_address = ?", addr[:])
+		query = query.Where("expiration_return_address = ?", addr)
 	}
 
 	if opts.expiresBefore != nil {
@@ -279,7 +279,7 @@ func (i *Indexer) basicOutputsQueryWithFilter(opts *BasicOutputFilterOptions) (*
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("sender = ?", addr[:])
+		query = query.Where("sender = ?", addr)
 	}
 
 	if opts.tag != nil && len(opts.tag) > 0 {

--- a/pkg/indexer/combined.go
+++ b/pkg/indexer/combined.go
@@ -1,0 +1,142 @@
+package indexer
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+)
+
+type CombinedFilterOptions struct {
+	hasNativeTokens     *bool
+	minNativeTokenCount *uint32
+	maxNativeTokenCount *uint32
+	unlockableByAddress *iotago.Address
+	pageSize            uint32
+	cursor              *string
+	createdBefore       *time.Time
+	createdAfter        *time.Time
+}
+
+type CombinedFilterOption func(*CombinedFilterOptions)
+
+func CombinedHasNativeTokens(value bool) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.hasNativeTokens = &value
+	}
+}
+
+func CombinedMinNativeTokenCount(value uint32) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.minNativeTokenCount = &value
+	}
+}
+
+func CombinedMaxNativeTokenCount(value uint32) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.maxNativeTokenCount = &value
+	}
+}
+
+func CombinedUnlockableByAddress(address iotago.Address) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.unlockableByAddress = &address
+	}
+}
+
+func CombinedPageSize(pageSize uint32) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.pageSize = pageSize
+	}
+}
+
+func CombinedCursor(cursor string) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.cursor = &cursor
+	}
+}
+
+func CombinedCreatedBefore(time time.Time) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.createdBefore = &time
+	}
+}
+
+func CombinedCreatedAfter(time time.Time) CombinedFilterOption {
+	return func(args *CombinedFilterOptions) {
+		args.createdAfter = &time
+	}
+}
+
+func combinedFilterOptions(optionalOptions []CombinedFilterOption) *CombinedFilterOptions {
+	result := &CombinedFilterOptions{}
+
+	for _, optionalOption := range optionalOptions {
+		optionalOption(result)
+	}
+
+	return result
+}
+
+func (o *CombinedFilterOptions) BasicFilterOptions() *BasicOutputFilterOptions {
+	return &BasicOutputFilterOptions{
+		hasNativeTokens:     o.hasNativeTokens,
+		minNativeTokenCount: o.minNativeTokenCount,
+		maxNativeTokenCount: o.maxNativeTokenCount,
+		unlockableByAddress: o.unlockableByAddress,
+		pageSize:            o.pageSize,
+		cursor:              o.cursor,
+		createdBefore:       o.createdBefore,
+		createdAfter:        o.createdAfter,
+	}
+}
+
+func (o *CombinedFilterOptions) AliasFilterOptions() *AliasFilterOptions {
+	return &AliasFilterOptions{
+		hasNativeTokens:     o.hasNativeTokens,
+		minNativeTokenCount: o.minNativeTokenCount,
+		maxNativeTokenCount: o.maxNativeTokenCount,
+		unlockableByAddress: o.unlockableByAddress,
+		pageSize:            o.pageSize,
+		cursor:              o.cursor,
+		createdBefore:       o.createdBefore,
+		createdAfter:        o.createdAfter,
+	}
+}
+
+func (o *CombinedFilterOptions) NFTFilterOptions() *NFTFilterOptions {
+	return &NFTFilterOptions{
+		hasNativeTokens:     o.hasNativeTokens,
+		minNativeTokenCount: o.minNativeTokenCount,
+		maxNativeTokenCount: o.maxNativeTokenCount,
+		unlockableByAddress: o.unlockableByAddress,
+		pageSize:            o.pageSize,
+		cursor:              o.cursor,
+		createdBefore:       o.createdBefore,
+		createdAfter:        o.createdAfter,
+	}
+}
+
+func (i *Indexer) CombinedOutputsWithFilters(filters ...CombinedFilterOption) *IndexerResult {
+	opts := combinedFilterOptions(filters)
+
+	basicQuery, err := i.basicOutputsQueryWithFilter(opts.BasicFilterOptions())
+	if err != nil {
+		return errorResult(err)
+	}
+
+	aliasQuery, err := i.aliasQueryWithFilter(opts.AliasFilterOptions())
+	if err != nil {
+		return errorResult(err)
+	}
+
+	nftQuery, err := i.nftOutputsQueryWithFilter(opts.NFTFilterOptions())
+	if err != nil {
+		return errorResult(err)
+	}
+
+	queries := []*gorm.DB{basicQuery, aliasQuery, nftQuery}
+
+	return i.combineOutputIDFilteredQueries(queries, opts.pageSize, opts.cursor)
+}

--- a/pkg/indexer/foundry.go
+++ b/pkg/indexer/foundry.go
@@ -11,11 +11,11 @@ import (
 )
 
 type foundry struct {
-	FoundryID        foundryIDBytes `gorm:"primaryKey;notnull"`
-	OutputID         outputIDBytes  `gorm:"unique;notnull"`
-	NativeTokenCount uint32         `gorm:"notnull;type:integer"`
-	AliasAddress     addressBytes   `gorm:"notnull;index:foundries_alias_address"`
-	CreatedAt        time.Time      `gorm:"notnull;index:foundries_created_at"`
+	FoundryID        []byte    `gorm:"primaryKey;notnull"`
+	OutputID         []byte    `gorm:"unique;notnull"`
+	NativeTokenCount uint32    `gorm:"notnull;type:integer"`
+	AliasAddress     []byte    `gorm:"notnull;index:foundries_alias_address"`
+	CreatedAt        time.Time `gorm:"notnull;index:foundries_created_at"`
 }
 
 func (o *foundry) String() string {

--- a/pkg/indexer/foundry.go
+++ b/pkg/indexer/foundry.go
@@ -125,7 +125,7 @@ func (i *Indexer) foundryOutputsQueryWithFilter(opts *FoundryFilterOptions) (*go
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("alias_address = ?", addr[:])
+		query = query.Where("alias_address = ?", addr)
 	}
 
 	if opts.createdBefore != nil {

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -90,7 +90,7 @@ func entryForOutput(outputID iotago.OutputID, output iotago.Output, timestampBoo
 		conditions := iotaOutput.UnlockConditionSet()
 
 		basic := &basicOutput{
-			OutputID:         make(outputIDBytes, iotago.OutputIDLength),
+			OutputID:         make([]byte, iotago.OutputIDLength),
 			NativeTokenCount: uint32(len(iotaOutput.NativeTokens)),
 			CreatedAt:        unixTime(timestampBooked),
 		}
@@ -151,8 +151,8 @@ func entryForOutput(outputID iotago.OutputID, output iotago.Output, timestampBoo
 		conditions := iotaOutput.UnlockConditionSet()
 
 		alias := &alias{
-			AliasID:          make(aliasIDBytes, iotago.AliasIDLength),
-			OutputID:         make(outputIDBytes, iotago.OutputIDLength),
+			AliasID:          make([]byte, iotago.AliasIDLength),
+			OutputID:         make([]byte, iotago.OutputIDLength),
 			NativeTokenCount: uint32(len(iotaOutput.NativeTokens)),
 			CreatedAt:        unixTime(timestampBooked),
 		}
@@ -202,8 +202,8 @@ func entryForOutput(outputID iotago.OutputID, output iotago.Output, timestampBoo
 		}
 
 		nft := &nft{
-			NFTID:            make(nftIDBytes, iotago.NFTIDLength),
-			OutputID:         make(outputIDBytes, iotago.OutputIDLength),
+			NFTID:            make([]byte, iotago.NFTIDLength),
+			OutputID:         make([]byte, iotago.OutputIDLength),
 			NativeTokenCount: uint32(len(iotaOutput.NativeTokens)),
 			CreatedAt:        unixTime(timestampBooked),
 		}
@@ -270,7 +270,7 @@ func entryForOutput(outputID iotago.OutputID, output iotago.Output, timestampBoo
 
 		foundry := &foundry{
 			FoundryID:        foundryID[:],
-			OutputID:         make(outputIDBytes, iotago.OutputIDLength),
+			OutputID:         make([]byte, iotago.OutputIDLength),
 			NativeTokenCount: uint32(len(iotaOutput.NativeTokens)),
 			CreatedAt:        unixTime(timestampBooked),
 		}

--- a/pkg/indexer/nft.go
+++ b/pkg/indexer/nft.go
@@ -11,19 +11,19 @@ import (
 )
 
 type nft struct {
-	NFTID                       nftIDBytes    `gorm:"primaryKey;notnull"`
-	OutputID                    outputIDBytes `gorm:"unique;notnull"`
-	NativeTokenCount            uint32        `gorm:"notnull;type:integer"`
-	Issuer                      addressBytes  `gorm:"index:nfts_issuer"`
-	Sender                      addressBytes  `gorm:"index:nfts_sender_tag"`
-	Tag                         []byte        `gorm:"index:nfts_sender_tag"`
-	Address                     addressBytes  `gorm:"notnull;index:nfts_address"`
+	NFTID                       []byte `gorm:"primaryKey;notnull"`
+	OutputID                    []byte `gorm:"unique;notnull"`
+	NativeTokenCount            uint32 `gorm:"notnull;type:integer"`
+	Issuer                      []byte `gorm:"index:nfts_issuer"`
+	Sender                      []byte `gorm:"index:nfts_sender_tag"`
+	Tag                         []byte `gorm:"index:nfts_sender_tag"`
+	Address                     []byte `gorm:"notnull;index:nfts_address"`
 	StorageDepositReturn        *uint64
-	StorageDepositReturnAddress addressBytes `gorm:"index:nfts_storage_deposit_return_address"`
+	StorageDepositReturnAddress []byte `gorm:"index:nfts_storage_deposit_return_address"`
 	TimelockTime                *time.Time
 	ExpirationTime              *time.Time
-	ExpirationReturnAddress     addressBytes `gorm:"index:nfts_expiration_return_address"`
-	CreatedAt                   time.Time    `gorm:"notnull;index:nfts_created_at"`
+	ExpirationReturnAddress     []byte    `gorm:"index:nfts_expiration_return_address"`
+	CreatedAt                   time.Time `gorm:"notnull;index:nfts_created_at"`
 }
 
 func (o *nft) String() string {

--- a/pkg/indexer/nft.go
+++ b/pkg/indexer/nft.go
@@ -224,7 +224,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("(address = ? OR expiration_return_address = ? OR storage_deposit_return_address = ?)", addr[:], addr[:], addr[:])
+		query = query.Where("(address = ? OR expiration_return_address = ? OR storage_deposit_return_address = ?)", addr, addr, addr)
 	}
 
 	if opts.address != nil {
@@ -232,7 +232,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("address = ?", addr[:])
+		query = query.Where("address = ?", addr)
 	}
 
 	if opts.hasStorageDepositReturnCondition != nil {
@@ -248,7 +248,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("storage_deposit_return_address = ?", addr[:])
+		query = query.Where("storage_deposit_return_address = ?", addr)
 	}
 
 	if opts.hasExpirationCondition != nil {
@@ -264,7 +264,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("expiration_return_address = ?", addr[:])
+		query = query.Where("expiration_return_address = ?", addr)
 	}
 
 	if opts.expiresBefore != nil {
@@ -296,7 +296,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("issuer = ?", addr[:])
+		query = query.Where("issuer = ?", addr)
 	}
 
 	if opts.sender != nil {
@@ -304,7 +304,7 @@ func (i *Indexer) nftOutputsQueryWithFilter(opts *NFTFilterOptions) (*gorm.DB, e
 		if err != nil {
 			return nil, err
 		}
-		query = query.Where("sender = ?", addr[:])
+		query = query.Where("sender = ?", addr)
 	}
 
 	if opts.tag != nil && len(opts.tag) > 0 {

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -22,10 +22,11 @@ var (
 )
 
 type outputIDBytes []byte
-type addressBytes []byte
-type nftIDBytes []byte
-type aliasIDBytes []byte
-type foundryIDBytes []byte
+
+//type addressBytes []byte
+//type nftIDBytes []byte
+//type aliasIDBytes []byte
+//type foundryIDBytes []byte
 
 type Status struct {
 	ID              uint `gorm:"primaryKey;notnull"`
@@ -59,7 +60,7 @@ func (q queryResults) IDs() iotago.OutputIDs {
 	return outputIDs
 }
 
-func addressBytesForAddress(addr iotago.Address) (addressBytes, error) {
+func addressBytesForAddress(addr iotago.Address) ([]byte, error) {
 	return addr.Serialize(serializer.DeSeriModeNoValidation, nil)
 }
 

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -21,13 +21,6 @@ var (
 	NullOutputID = iotago.OutputID{}
 )
 
-type outputIDBytes []byte
-
-//type addressBytes []byte
-//type nftIDBytes []byte
-//type aliasIDBytes []byte
-//type foundryIDBytes []byte
-
 type Status struct {
 	ID              uint `gorm:"primaryKey;notnull"`
 	LedgerIndex     uint32
@@ -37,16 +30,9 @@ type Status struct {
 }
 
 type queryResult struct {
-	OutputID    outputIDBytes
+	OutputID    []byte
 	Cursor      string
 	LedgerIndex uint32
-}
-
-func (o outputIDBytes) ID() iotago.OutputID {
-	id := iotago.OutputID{}
-	copy(id[:], o)
-
-	return id
 }
 
 type queryResults []queryResult
@@ -54,7 +40,7 @@ type queryResults []queryResult
 func (q queryResults) IDs() iotago.OutputIDs {
 	outputIDs := iotago.OutputIDs{}
 	for _, r := range q {
-		outputIDs = append(outputIDs, r.OutputID.ID())
+		outputIDs = append(outputIDs, iotago.OutputID(r.OutputID))
 	}
 
 	return outputIDs

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -126,9 +126,9 @@ func (i *Indexer) combineOutputIDFilteredQueries(queries []*gorm.DB, pageSize ui
 		filteredQueries[q] = filtered
 	}
 
-	unionQueryItem := "SELECT output_id, created_at FROM (?);"
+	unionQueryItem := "SELECT output_id, created_at FROM (?) as temp;"
 	if pageSize > 0 {
-		unionQueryItem = "SELECT output_id, created_at, cursor FROM (?);"
+		unionQueryItem = "SELECT output_id, created_at, cursor FROM (?) as temp;"
 	}
 	repeatedUnionQueryItem := strings.Split(strings.Repeat(unionQueryItem, len(queries)), ";")
 	unionQuery := strings.Join(repeatedUnionQueryItem[:len(repeatedUnionQueryItem)-1], " UNION ")

--- a/pkg/indexer/types.go
+++ b/pkg/indexer/types.go
@@ -96,6 +96,7 @@ func (i *Indexer) filteredQuery(query *gorm.DB, pageSize uint32, cursor *string)
 			i.LogErrorfAndExit("Unsupported db engine pagination queries: %s", i.engine)
 		}
 
+		// We use pageSize + 1 to load the next item to use as the cursor
 		query = query.Select("output_id", "created_at", cursorQuery).Limit(int(pageSize + 1))
 
 		if cursor != nil {
@@ -145,6 +146,7 @@ func (i *Indexer) combineOutputIDFilteredQueries(queries []*gorm.DB, pageSize ui
 	repeatedUnionQueryItem := strings.Split(strings.Repeat(unionQueryItem, len(queries)), ";")
 	unionQuery := strings.Join(repeatedUnionQueryItem[:len(repeatedUnionQueryItem)-1], " UNION ")
 
+	// We use pageSize + 1 to load the next item to use as the cursor
 	unionQuery = fmt.Sprintf("%s ORDER BY created_at asc, output_id asc LIMIT %d", unionQuery, pageSize+1)
 
 	rawQuery := i.db.Raw(unionQuery, filteredQueries...)

--- a/pkg/server/restapi.go
+++ b/pkg/server/restapi.go
@@ -10,6 +10,9 @@ const (
 	// ParameterNFTID is used to identify a nft by its ID.
 	ParameterNFTID = "nftID"
 
+	// QueryParameterUnlockableByAddress is used to filter for all unlock conditions regarding a certain address.
+	QueryParameterUnlockableByAddress = "unlockableByAddress"
+
 	// QueryParameterAddress is used to filter for a certain address.
 	QueryParameterAddress = "address"
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -156,12 +156,20 @@ func (s *IndexerServer) basicOutputsWithFilter(c echo.Context) (*outputsResponse
 		filters = append(filters, indexer.BasicOutputMaxNativeTokenCount(value))
 	}
 
+	if len(c.QueryParam(QueryParameterUnlockableByAddress)) > 0 {
+		addr, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterUnlockableByAddress)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, indexer.BasicOutputUnlockableByAddress(addr))
+	}
+
 	if len(c.QueryParam(QueryParameterAddress)) > 0 {
 		addr, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterAddress)
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, indexer.BasicOutputUnlockableByAddress(addr))
+		filters = append(filters, indexer.BasicOutputUnlockAddress(addr))
 	}
 
 	if len(c.QueryParam(QueryParameterHasStorageDepositReturn)) > 0 {
@@ -315,6 +323,14 @@ func (s *IndexerServer) aliasesWithFilter(c echo.Context) (*outputsResponse, err
 		filters = append(filters, indexer.AliasMaxNativeTokenCount(value))
 	}
 
+	if len(c.QueryParam(QueryParameterUnlockableByAddress)) > 0 {
+		addr, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterUnlockableByAddress)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, indexer.AliasUnlockableByAddress(addr))
+	}
+
 	if len(c.QueryParam(QueryParameterStateController)) > 0 {
 		stateController, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterStateController)
 		if err != nil {
@@ -410,12 +426,20 @@ func (s *IndexerServer) nftsWithFilter(c echo.Context) (*outputsResponse, error)
 		filters = append(filters, indexer.NFTMaxNativeTokenCount(value))
 	}
 
+	if len(c.QueryParam(QueryParameterUnlockableByAddress)) > 0 {
+		addr, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterUnlockableByAddress)
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, indexer.NFTUnlockableByAddress(addr))
+	}
+
 	if len(c.QueryParam(QueryParameterAddress)) > 0 {
 		addr, err := httpserver.ParseBech32AddressQueryParam(c, s.Bech32HRP, QueryParameterAddress)
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, indexer.NFTUnlockableByAddress(addr))
+		filters = append(filters, indexer.NFTUnlockAddress(addr))
 	}
 
 	if len(c.QueryParam(QueryParameterHasStorageDepositReturn)) > 0 {

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -156,7 +156,7 @@ func (s *IndexerServer) combinedOutputsWithFilter(c echo.Context) (*outputsRespo
 	}
 
 	if len(c.QueryParam(QueryParameterMinNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +164,7 @@ func (s *IndexerServer) combinedOutputsWithFilter(c echo.Context) (*outputsRespo
 	}
 
 	if len(c.QueryParam(QueryParameterMaxNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +218,7 @@ func (s *IndexerServer) basicOutputsWithFilter(c echo.Context) (*outputsResponse
 	}
 
 	if len(c.QueryParam(QueryParameterMinNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +226,7 @@ func (s *IndexerServer) basicOutputsWithFilter(c echo.Context) (*outputsResponse
 	}
 
 	if len(c.QueryParam(QueryParameterMaxNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +385,7 @@ func (s *IndexerServer) aliasesWithFilter(c echo.Context) (*outputsResponse, err
 	}
 
 	if len(c.QueryParam(QueryParameterMinNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -393,7 +393,7 @@ func (s *IndexerServer) aliasesWithFilter(c echo.Context) (*outputsResponse, err
 	}
 
 	if len(c.QueryParam(QueryParameterMaxNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (s *IndexerServer) nftsWithFilter(c echo.Context) (*outputsResponse, error)
 	}
 
 	if len(c.QueryParam(QueryParameterMinNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +496,7 @@ func (s *IndexerServer) nftsWithFilter(c echo.Context) (*outputsResponse, error)
 	}
 
 	if len(c.QueryParam(QueryParameterMaxNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -663,7 +663,7 @@ func (s *IndexerServer) foundriesWithFilter(c echo.Context) (*outputsResponse, e
 	}
 
 	if len(c.QueryParam(QueryParameterMinNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMinNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}
@@ -671,7 +671,7 @@ func (s *IndexerServer) foundriesWithFilter(c echo.Context) (*outputsResponse, e
 	}
 
 	if len(c.QueryParam(QueryParameterMaxNativeTokenCount)) > 0 {
-		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput)
+		value, err := httpserver.ParseUint32QueryParam(c, QueryParameterMaxNativeTokenCount, iotago.MaxNativeTokenCountPerOutput) // Use the iotago.MaxNativeTokenCountPerOutput as an upper bound check
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Added `unlockableByAddress` filter to `/outputs/basic`, `/outputs/alias` and `outputs/nft` routes which checks for the different address unlocks with an `OR` condition
- Added new `/outputs` route that combines Basic, Alias and NFT outputs in the result. It supports some of the common filtering options including the above `unlockableByAddress` one.